### PR TITLE
Add merkle log proof mechanism

### DIFF
--- a/archivist/proof_mechanism.py
+++ b/archivist/proof_mechanism.py
@@ -17,3 +17,5 @@ class ProofMechanism(Enum):
     __RESERVED = 1
     #: Assets and events are proven using a hash of the originator's evidence
     SIMPLE_HASH = 2
+    #: Assets and events are proven using a merkle log hash of the originator's evidence
+    MERKLE_LOG = 3

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -29,6 +29,7 @@ jupyter
 jupyterLabDesktop
 kwargs
 macclesfield
+merkle
 mimetype
 onwards
 params

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -20,17 +20,18 @@ from .testassetsconstants import (
     ASSET_NAME,
     ATTRS,
     FIXTURES,
+    MERKLE_LOG,
     PRIMARY_IMAGE,
-    PROPS,
-    REQUEST_EXISTS,
-    REQUEST_EXISTS_ATTACHMENTS,
-    REQUEST_EXISTS_KWARGS,
-    REQUEST_EXISTS_KWARGS_ATTACHMENTS,
-    REQUEST_EXISTS_KWARGS_LOCATION,
-    REQUEST_EXISTS_LOCATION,
-    REQUEST_EXISTS_LOCATION_IDENTITY,
-    REQUEST_FIXTURES_KWARGS,
-    REQUEST_KWARGS,
+    REQUEST_EXISTS_ATTACHMENTS_SIMPLE_HASH,
+    REQUEST_EXISTS_KWARGS_ATTACHMENTS_SIMPLE_HASH,
+    REQUEST_EXISTS_KWARGS_LOCATION_SIMPLE_HASH,
+    REQUEST_EXISTS_KWARGS_SIMPLE_HASH,
+    REQUEST_EXISTS_LOCATION_IDENTITY_SIMPLE_HASH,
+    REQUEST_EXISTS_LOCATION_SIMPLE_HASH,
+    REQUEST_EXISTS_SIMPLE_HASH,
+    REQUEST_FIXTURES_KWARGS_SIMPLE_HASH,
+    REQUEST_KWARGS_MERKLE_LOG,
+    REQUEST_KWARGS_SIMPLE_HASH,
     RESPONSE,
     RESPONSE_ATTACHMENTS,
     RESPONSE_EXISTS,
@@ -41,6 +42,7 @@ from .testassetsconstants import (
     RESPONSE_LOCATION,
     RESPONSE_NO_CONFIRMATION,
     RESPONSE_PENDING,
+    SIMPLE_HASH,
     SUBPATH,
     TestAssetsBase,
     TestAssetsBaseConfirm,
@@ -84,7 +86,9 @@ class TestAssetsCreate(TestAssetsBase):
         with mock.patch.object(self.arch.session, "post", autospec=True) as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=False)
+            asset = self.arch.assets.create(
+                props=SIMPLE_HASH, attrs=ATTRS, confirm=False
+            )
             args, kwargs = mock_post.call_args
             self.assertEqual(
                 args,
@@ -93,7 +97,44 @@ class TestAssetsCreate(TestAssetsBase):
             )
             self.assertEqual(
                 kwargs,
-                REQUEST_KWARGS,
+                REQUEST_KWARGS_SIMPLE_HASH,
+                msg="CREATE method kwargs called incorrectly",
+            )
+            self.assertEqual(
+                asset,
+                RESPONSE,
+                msg="CREATE incorrect response",
+            )
+            self.assertEqual(
+                asset.primary_image,
+                PRIMARY_IMAGE,
+                msg="Incorrect primary image",
+            )
+            self.assertEqual(
+                asset.name,
+                ASSET_NAME,
+                msg="Incorrect name property",
+            )
+
+    def test_assets_create_merkle_log(self):
+        """
+        Test asset creation
+        """
+        with mock.patch.object(self.arch.session, "post", autospec=True) as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+
+            asset = self.arch.assets.create(
+                props=MERKLE_LOG, attrs=ATTRS, confirm=False
+            )
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                args,
+                (f"url/{ROOT}/{ASSETS_SUBPATH}/{ASSETS_LABEL}",),
+                msg="CREATE method args called incorrectly",
+            )
+            self.assertEqual(
+                kwargs,
+                REQUEST_KWARGS_MERKLE_LOG,
                 msg="CREATE method kwargs called incorrectly",
             )
             self.assertEqual(
@@ -120,7 +161,7 @@ class TestAssetsCreate(TestAssetsBase):
         arch.fixtures = FIXTURES
         with mock.patch.object(arch.session, "post", autospec=True) as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE_FIXTURES)
-            asset = arch.assets.create(props=PROPS, attrs=ATTRS, confirm=False)
+            asset = arch.assets.create(props=SIMPLE_HASH, attrs=ATTRS, confirm=False)
             args, kwargs = mock_post.call_args
             self.assertEqual(
                 args,
@@ -129,7 +170,7 @@ class TestAssetsCreate(TestAssetsBase):
             )
             self.assertEqual(
                 kwargs,
-                REQUEST_FIXTURES_KWARGS,
+                REQUEST_FIXTURES_KWARGS_SIMPLE_HASH,
                 msg="CREATE method kwargs called incorrectly",
             )
             self.assertEqual(
@@ -149,7 +190,7 @@ class TestAssetsCreate(TestAssetsBase):
             mock_get.return_value = MockResponse(200, **RESPONSE_NO_CONFIRMATION)
 
             with self.assertRaises(ArchivistUnconfirmedError):
-                self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+                self.arch.assets.create(props=SIMPLE_HASH, attrs=ATTRS, confirm=True)
 
     def test_assets_create_with_confirmation_failed_status(self):
         """
@@ -164,7 +205,7 @@ class TestAssetsCreate(TestAssetsBase):
                 MockResponse(200, **RESPONSE_FAILED),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+                self.arch.assets.create(props=SIMPLE_HASH, attrs=ATTRS, confirm=True)
 
     def test_assets_create_with_confirmation_always_pending_status(self):
         """
@@ -184,7 +225,7 @@ class TestAssetsCreate(TestAssetsBase):
                 MockResponse(200, **RESPONSE_PENDING),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+                self.arch.assets.create(props=SIMPLE_HASH, attrs=ATTRS, confirm=True)
 
 
 class TestAssetsCreateConfirm(TestAssetsBaseConfirm):
@@ -201,7 +242,9 @@ class TestAssetsCreateConfirm(TestAssetsBaseConfirm):
         ) as mock_post, mock.patch.object(self.arch.session, "get") as mock_get:
             mock_post.return_value = MockResponse(200, **RESPONSE)
             mock_get.return_value = MockResponse(200, **RESPONSE)
-            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+            asset = self.arch.assets.create(
+                props=SIMPLE_HASH, attrs=ATTRS, confirm=True
+            )
             self.assertEqual(
                 asset,
                 RESPONSE,
@@ -217,7 +260,9 @@ class TestAssetsCreateConfirm(TestAssetsBaseConfirm):
         ) as mock_post, mock.patch.object(self.arch.session, "get") as mock_get:
             mock_post.return_value = MockResponse(200, **RESPONSE)
             mock_get.return_value = MockResponse(200, **RESPONSE)
-            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=False)
+            asset = self.arch.assets.create(
+                props=SIMPLE_HASH, attrs=ATTRS, confirm=False
+            )
             self.arch.assets.wait_for_confirmation(asset["identity"])
             self.assertEqual(
                 asset,
@@ -237,7 +282,9 @@ class TestAssetsCreateConfirm(TestAssetsBaseConfirm):
                 MockResponse(200, **RESPONSE_PENDING),
                 MockResponse(200, **RESPONSE),
             ]
-            asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+            asset = self.arch.assets.create(
+                props=SIMPLE_HASH, attrs=ATTRS, confirm=True
+            )
             self.assertEqual(
                 asset,
                 RESPONSE,
@@ -266,7 +313,7 @@ class TestAssetsCreateIfNotExists(TestAssetsBase):
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
             asset, existed = self.arch.assets.create_if_not_exists(
-                data=REQUEST_EXISTS,
+                data=REQUEST_EXISTS_SIMPLE_HASH,
                 confirm=False,
             )
             mock_post.assert_not_called()
@@ -389,7 +436,9 @@ class TestAssetsCreateIfNotExists(TestAssetsBase):
         Test asset creation
         """
         self.common_assets_create_if_not_exists_nonexistent_asset(
-            REQUEST_EXISTS, REQUEST_EXISTS_KWARGS, RESPONSE_EXISTS
+            REQUEST_EXISTS_SIMPLE_HASH,
+            REQUEST_EXISTS_KWARGS_SIMPLE_HASH,
+            RESPONSE_EXISTS,
         )
 
     def test_assets_create_if_not_exists_nonexistent_asset_location(self):
@@ -397,8 +446,8 @@ class TestAssetsCreateIfNotExists(TestAssetsBase):
         Test asset creation
         """
         self.common_assets_create_if_not_exists_nonexistent_asset(
-            REQUEST_EXISTS_LOCATION,
-            REQUEST_EXISTS_KWARGS_LOCATION,
+            REQUEST_EXISTS_LOCATION_SIMPLE_HASH,
+            REQUEST_EXISTS_KWARGS_LOCATION_SIMPLE_HASH,
             RESPONSE_EXISTS_LOCATION,
             loc_resp=RESPONSE_LOCATION,
         )
@@ -408,8 +457,8 @@ class TestAssetsCreateIfNotExists(TestAssetsBase):
         Test asset creation
         """
         self.common_assets_create_if_not_exists_nonexistent_asset(
-            REQUEST_EXISTS_LOCATION_IDENTITY,
-            REQUEST_EXISTS_KWARGS_LOCATION,
+            REQUEST_EXISTS_LOCATION_IDENTITY_SIMPLE_HASH,
+            REQUEST_EXISTS_KWARGS_LOCATION_SIMPLE_HASH,
             RESPONSE_EXISTS_LOCATION,
         )
 
@@ -418,8 +467,8 @@ class TestAssetsCreateIfNotExists(TestAssetsBase):
         Test asset creation
         """
         self.common_assets_create_if_not_exists_nonexistent_asset(
-            REQUEST_EXISTS_ATTACHMENTS,
-            REQUEST_EXISTS_KWARGS_ATTACHMENTS,
+            REQUEST_EXISTS_ATTACHMENTS_SIMPLE_HASH,
+            REQUEST_EXISTS_KWARGS_ATTACHMENTS_SIMPLE_HASH,
             RESPONSE_EXISTS_ATTACHMENTS,
             attachments_resp=RESPONSE_ATTACHMENTS,
         )

--- a/unittests/testassetsconstants.py
+++ b/unittests/testassetsconstants.py
@@ -77,8 +77,11 @@ ATTRS_FIXTURES = {
 }
 
 # case 1 create
-PROPS = {
+SIMPLE_HASH = {
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
+}
+MERKLE_LOG = {
+    "proof_mechanism": ProofMechanism.MERKLE_LOG.name,
 }
 ATTRS = {
     "arc_firmware_version": "1.0",
@@ -93,7 +96,7 @@ ATTRS = {
         PRIMARY_IMAGE,
     ],
 }
-REQUEST = {
+REQUEST_SIMPLE_HASH = {
     "behaviours": ASSET_BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
     "attributes": {
@@ -110,7 +113,30 @@ REQUEST = {
         ],
     },
 }
-REQUEST_KWARGS = {
+REQUEST_KWARGS_MERKLE_LOG = {
+    "json": {
+        "behaviours": ASSET_BEHAVIOURS,
+        "proof_mechanism": ProofMechanism.MERKLE_LOG.name,
+        "attributes": {
+            "arc_firmware_version": "1.0",
+            "arc_serial_number": "vtl-x4-07",
+            "arc_description": "Traffic flow control light at A603 North East",
+            "arc_display_type": "Traffic light with violation camera",
+            "some_custom_attribute": "value",
+            "arc_display_name": ASSET_NAME,
+            "arc_attachments": [
+                TERTIARY_IMAGE,
+                SECONDARY_IMAGE,
+                PRIMARY_IMAGE,
+            ],
+        },
+    },
+    "headers": {
+        "authorization": "Bearer authauthauth",
+    },
+    "verify": True,
+}
+REQUEST_KWARGS_SIMPLE_HASH = {
     "json": {
         "behaviours": ASSET_BEHAVIOURS,
         "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
@@ -153,7 +179,7 @@ RESPONSE = {
 }
 
 # case 2 create if not exists
-REQUEST_EXISTS = {
+REQUEST_EXISTS_SIMPLE_HASH = {
     "selector": [
         {
             "attributes": [
@@ -174,7 +200,7 @@ REQUEST_EXISTS = {
         "some_custom_attribute": "value",
     },
 }
-REQUEST_EXISTS_KWARGS = {
+REQUEST_EXISTS_KWARGS_SIMPLE_HASH = {
     "json": {
         "behaviours": ASSET_BEHAVIOURS,
         "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
@@ -210,7 +236,7 @@ RESPONSE_EXISTS = {
 }
 
 # case 3 create if not exists with attachments
-REQUEST_EXISTS_ATTACHMENTS = {
+REQUEST_EXISTS_ATTACHMENTS_SIMPLE_HASH = {
     "selector": [
         {
             "attributes": [
@@ -242,7 +268,7 @@ REQUEST_EXISTS_ATTACHMENTS = {
         },
     ],
 }
-REQUEST_EXISTS_KWARGS_ATTACHMENTS = {
+REQUEST_EXISTS_KWARGS_ATTACHMENTS_SIMPLE_HASH = {
     "json": {
         "behaviours": ASSET_BEHAVIOURS,
         "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
@@ -317,7 +343,7 @@ RESPONSE_EXISTS_ATTACHMENTS = {
 }
 
 # case 4 create if not exists with location
-REQUEST_EXISTS_LOCATION = {
+REQUEST_EXISTS_LOCATION_SIMPLE_HASH = {
     "selector": [
         {
             "attributes": [
@@ -359,7 +385,7 @@ REQUEST_EXISTS_LOCATION = {
         },
     },
 }
-REQUEST_EXISTS_KWARGS_LOCATION = {
+REQUEST_EXISTS_KWARGS_LOCATION_SIMPLE_HASH = {
     "json": {
         "behaviours": ASSET_BEHAVIOURS,
         "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
@@ -410,7 +436,7 @@ RESPONSE_LOCATION = {
     },
 }
 # case 5 create if not exists with location identity
-REQUEST_EXISTS_LOCATION_IDENTITY = {
+REQUEST_EXISTS_LOCATION_IDENTITY_SIMPLE_HASH = {
     "selector": [
         {
             "attributes": [
@@ -437,13 +463,13 @@ REQUEST_EXISTS_LOCATION_IDENTITY = {
 
 # ---------------
 
-REQUEST_FIXTURES = {
+REQUEST_FIXTURES_SIMPLE_HASH = {
     "behaviours": ASSET_BEHAVIOURS,
     "proof_mechanism": ProofMechanism.SIMPLE_HASH.name,
     "attributes": ATTRS_FIXTURES,
 }
-REQUEST_FIXTURES_KWARGS = {
-    "json": REQUEST_FIXTURES,
+REQUEST_FIXTURES_KWARGS_SIMPLE_HASH = {
+    "json": REQUEST_FIXTURES_SIMPLE_HASH,
     "headers": {
         "authorization": "Bearer authauthauth",
     },

--- a/unittests/testproof_mechanism.py
+++ b/unittests/testproof_mechanism.py
@@ -14,7 +14,7 @@ class TestProofMechanism(TestCase):
     Test proof mechanism for archivist
     """
 
-    def test_proof_mechanism(self):
+    def test_proof_mechanism_simple_hash(self):
         """
         Test proof_mechanism
         """
@@ -23,6 +23,18 @@ class TestProofMechanism(TestCase):
         self.assertEqual(
             ProofMechanism.SIMPLE_HASH.name,
             "SIMPLE_HASH",
+            msg="Incorrect value",
+        )
+
+    def test_proof_mechanism_metkle_log(self):
+        """
+        Test proof_mechanism
+        """
+        self.assertEqual(ProofMechanism.MERKLE_LOG.value, 3, msg="Incorrect value")
+
+        self.assertEqual(
+            ProofMechanism.MERKLE_LOG.name,
+            "MERKLE_LOG",
             msg="Incorrect value",
         )
 


### PR DESCRIPTION
The ability to specify merkle log as the proof mechanism is added. Note that this requires backend support which will only be available at some future date.

[AB#9103](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9103)