### PR TITLE
Fix confirmation timeouts

### DIFF
--- a/archivist/confirmer.py
+++ b/archivist/confirmer.py
@@ -137,12 +137,19 @@ def _wait_for_confirmed(
 ) -> bool:
     """Return False until all entities are confirmed"""
 
-    # look for unconfirmed entities
+    # look for pending entities
     newprops = deepcopy(props) if props else {}
     newprops[CONFIRMATION_STATUS] = ConfirmationStatus.PENDING.name
+    LOGGER.debug("Count pending entities %s", newprops)
+    pending_count = self.count(props=newprops, **kwargs)
 
-    LOGGER.debug("Count unconfirmed entities %s", newprops)
-    count = self.count(props=newprops, **kwargs)
+    # look for stored entities
+    newprops = deepcopy(props) if props else {}
+    newprops[CONFIRMATION_STATUS] = ConfirmationStatus.STORED.name
+    LOGGER.debug("Count stored entities %s", newprops)
+    stored_count = self.count(props=newprops, **kwargs)
+
+    count = pending_count + stored_count
 
     if count == 0:
         # did any fail

--- a/archivist/confirmer.py
+++ b/archivist/confirmer.py
@@ -102,11 +102,11 @@ def _wait_for_confirmation(self: Managers, identity: str) -> ReturnTypes:
         )
 
     # Simple hash and merkleLog
-    if status == ConfirmationStatus.CONFIRMED.name:
-        return entity
-
-    # merkle_log
-    if ConfirmationStatus[status].value >= ConfirmationStatus.COMMITTED.value:
+    if status in (
+        ConfirmationStatus.CONFIRMED.name,
+        ConfirmationStatus.COMMITTED.name,
+        ConfirmationStatus.UNEQUIVOCAL.name,
+    ):
         return entity
 
     return None  # pyright: ignore

--- a/archivist/confirmer.py
+++ b/archivist/confirmer.py
@@ -101,7 +101,7 @@ def _wait_for_confirmation(self: Managers, identity: str) -> ReturnTypes:
             f"confirmation for {identity} FAILED - this is unusable"
         )
 
-    # Simple hash
+    # Simple hash and merkleLog
     if status == ConfirmationStatus.CONFIRMED.name:
         return entity
 

--- a/archivist/subjects_confirmer.py
+++ b/archivist/subjects_confirmer.py
@@ -18,7 +18,7 @@ from .errors import ArchivistUnconfirmedError
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 from .utils import backoff_handler
 
-MAX_TIME = 1200
+MAX_TIME = 300
 
 LOGGER = getLogger(__name__)
 
@@ -37,6 +37,7 @@ def __on_giveup_confirmation(details):
 
 @backoff.on_predicate(
     backoff.expo,
+    max_value=30.0,
     logger=None,  # pyright: ignore
     max_time=__lookup_max_time,
     on_backoff=backoff_handler,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 # for the published wheel - the file docs/requirements.txt
 # must be kept in sync with this file.
 #
-# upgrading to 2.2 of backoff raises all kinds of type hint errors so
-# this will require more work - stick to 1.11 for now.
 backoff~=2.2.1
 certifi
 flatten-dict~=0.4

--- a/unittests/testassetsconstants.py
+++ b/unittests/testassetsconstants.py
@@ -537,6 +537,12 @@ RESPONSE_PENDING = {
     "attributes": ATTRS,
     "confirmation_status": "PENDING",
 }
+RESPONSE_STORED = {
+    "identity": IDENTITY,
+    "behaviours": ASSET_BEHAVIOURS,
+    "attributes": ATTRS,
+    "confirmation_status": "STORED",
+}
 RESPONSE_FAILED = {
     "identity": IDENTITY,
     "behaviours": ASSET_BEHAVIOURS,
@@ -553,7 +559,7 @@ class TestAssetsBase(TestCase):
     maxDiff = None
 
     def setUp(self):
-        self.arch = Archivist("url", "authauthauth", max_time=1)
+        self.arch = Archivist("url", "authauthauth", max_time=0.5)
 
     def tearDown(self):
         self.arch.close()

--- a/unittests/testassetswait.py
+++ b/unittests/testassetswait.py
@@ -18,6 +18,7 @@ from .mock_response import MockResponse
 from .testassetsconstants import (
     RESPONSE_FAILED,
     RESPONSE_PENDING,
+    RESPONSE_STORED,
     SUBPATH,
     TestAssetsBase,
 )
@@ -45,9 +46,11 @@ class TestAssetsWait(TestAssetsBase):
         status = (
             {"page_size": 1},
             {"page_size": 1, "confirmation_status": "PENDING"},
+            {"page_size": 1, "confirmation_status": "STORED"},
             {"page_size": 1, "confirmation_status": "FAILED"},
         )
         with mock.patch.object(self.arch.session, "get") as mock_get:
+            # there are 2 gets for each retry - one for PENDING and one for STORED
             mock_get.side_effect = [
                 MockResponse(
                     200,
@@ -55,6 +58,16 @@ class TestAssetsWait(TestAssetsBase):
                     assets=[
                         RESPONSE_PENDING,
                     ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 0},
+                    assets=[],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 0},
+                    assets=[],
                 ),
                 MockResponse(
                     200,
@@ -110,6 +123,8 @@ class TestAssetsWait(TestAssetsBase):
         """
         ## last call to get looks for FAILED assets
         with mock.patch.object(self.arch.session, "get") as mock_get:
+            # there are 2 gets for each retry - one for PENDING and one for STORED
+            # enough entries to be supplied so that timeout occurs
             mock_get.side_effect = [
                 MockResponse(
                     200,
@@ -122,7 +137,7 @@ class TestAssetsWait(TestAssetsBase):
                     200,
                     headers={HEADERS_TOTAL_COUNT: 2},
                     assets=[
-                        RESPONSE_PENDING,
+                        RESPONSE_STORED,
                     ],
                 ),
                 MockResponse(
@@ -136,7 +151,7 @@ class TestAssetsWait(TestAssetsBase):
                     200,
                     headers={HEADERS_TOTAL_COUNT: 2},
                     assets=[
-                        RESPONSE_PENDING,
+                        RESPONSE_STORED,
                     ],
                 ),
                 MockResponse(
@@ -150,7 +165,35 @@ class TestAssetsWait(TestAssetsBase):
                     200,
                     headers={HEADERS_TOTAL_COUNT: 2},
                     assets=[
+                        RESPONSE_STORED,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
                         RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_STORED,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_PENDING,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 2},
+                    assets=[
+                        RESPONSE_STORED,
                     ],
                 ),
             ]
@@ -171,6 +214,11 @@ class TestAssetsWait(TestAssetsBase):
                     assets=[
                         RESPONSE_PENDING,
                     ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 0},
+                    assets=[],
                 ),
                 MockResponse(
                     200,

--- a/unittests/testeventswait.py
+++ b/unittests/testeventswait.py
@@ -35,12 +35,13 @@ class TestEventsWait(TestEventsBase):
 
     def test_events_wait_for_confirmed(self):
         """
-        Test event counting
+        Test event confirmation
         """
         ## last call to get looks for FAILED assets
         status = (
             {"page_size": 1},
             {"page_size": 1, "confirmation_status": "PENDING"},
+            {"page_size": 1, "confirmation_status": "STORED"},
             {"page_size": 1, "confirmation_status": "FAILED"},
         )
         with mock.patch.object(self.arch.session, "get") as mock_get:
@@ -51,6 +52,11 @@ class TestEventsWait(TestEventsBase):
                     assets=[
                         RESPONSE_PENDING,
                     ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 0},
+                    assets=[],
                 ),
                 MockResponse(
                     200,


### PR DESCRIPTION
Reduced max timeout from 1200 to 300s
Set maximum retry interval to 30s
Change wait_for_confirmed for STORED entities

[AB#9103](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9103)