### PR TITLE
Add tracking headers

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -108,11 +108,15 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
         fixtures: "dict[str,dict[Any,Any]]|None" = None,
         verify: bool = True,
         max_time: float = MAX_TIME,
+        partner_id: str = "",
+        user_agent: str = "",
     ):
         super().__init__(
             fixtures=fixtures,
             verify=verify,
             max_time=max_time,
+            partner_id=partner_id,
+            user_agent=user_agent,
         )
 
         if isinstance(auth, tuple):
@@ -214,10 +218,12 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
             fixtures=deepcopy(self._fixtures),
             verify=self._verify,
             max_time=self._max_time,
+            partner_id=self._partner_id,
+            user_agent=self._user_agent,
         )
 
     def _add_headers(self, headers: "dict[str,str]|None") -> "dict[str,Any]":
-        newheaders = {**headers} if isinstance(headers, dict) else {}
+        newheaders = super()._add_headers(headers)
 
         auth = self.auth  # this may trigger a refetch so only do it once here
         # for appidp endpoint there may not be an authtoken

--- a/archivist/constants.py
+++ b/archivist/constants.py
@@ -13,6 +13,10 @@ ASSET_BEHAVIOURS = [
     "RecordEvidence",
 ]
 
+USER_AGENT = "DataTrails-User-Agent"
+USER_AGENT_PREFIX = "pysdk/"
+PARTNER_ID = "DataTrails-Partner-ID"
+
 # define in MIME canonical form
 HEADERS_REQUEST_TOTAL_COUNT = "X-Request-Total-Count"
 HEADERS_TOTAL_COUNT = "X-Total-Count"

--- a/archivist/parser.py
+++ b/archivist/parser.py
@@ -129,6 +129,15 @@ def common_parser(description: str):
         default=None,
         help="namespace of item population",
     )
+    parser.add_argument(
+        "-p",
+        "--partner_id",
+        type=str,
+        dest="partner_id",
+        action="store",
+        default=None,
+        help="partner id",
+    )
 
     return parser
 
@@ -171,7 +180,12 @@ def endpoint(args):
         LOGGER.error("Critical error.  Aborting.")
         sys_exit(1)
 
-    arch = Archivist(args.url, auth, fixtures=fixtures)
+    arch = Archivist(
+        args.url,
+        auth,
+        fixtures=fixtures,
+        partner_id=args.partner_id,
+    )
     if arch is None:
         LOGGER.error("Critical error.  Aborting.")
         sys_exit(1)

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -75,7 +75,7 @@ def main():
     create an example archivist connection and create an asset.
 
     """
-    # optional call to set the logger level for all subsystems. The argumant can
+    # optional call to set the logger level for all subsystems. The argument can
     # be either "INFO" or "DEBUG". For more sophisticated logging control see the
     # documentation.
     set_logger("INFO")
@@ -97,10 +97,14 @@ def main():
     # Initialize connection to Archivist. max_time is the time to wait for confirmation
     # of an asset or event creation - the default is 300 seconds but one can optionally
     # specify a different value.
+    # The optional partner id field is allocated by Datatrails to partners - partners are then
+    # expected to specify this value when submitting any request to the archivist product.
+    # Leave blank if if you do not have a partner ID.
     with Archivist(
         "https://app.datatrails.ai",
         auth,
         max_time=300,
+        partner_id="acme/f7a6beef-f01c-4b39-a494-3fa6b45d6bf4",
     ) as arch:
         # Create a new asset
         asset = create_asset(arch)

--- a/functests/constants.py
+++ b/functests/constants.py
@@ -1,9 +1,13 @@
 """
-hide docstringss
+constantss
 """
 
 # pylint: disable=missing-docstring
+
 import unittest
+
+PARTNER_ID_VALUE = "acmecorp"
+USER_AGENT_VALUE = "functests/v0.1.0"
 
 
 class TestCase(unittest.TestCase):

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -14,7 +14,11 @@ from archivist.archivist import Archivist
 from archivist.constants import ASSET_BEHAVIOURS
 from archivist.utils import get_auth
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -117,7 +121,12 @@ class TestAccessPoliciesBase(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
 
         # these are for access_policies
         self.ac_props = deepcopy(PROPS)
@@ -298,8 +307,12 @@ class TestAccessPoliciesShare(TestAccessPoliciesBase):
         super().setUp()
         with open(getenv("DATATRAILS_AUTHTOKEN_FILENAME_2"), encoding="utf-8") as fd:
             auth_2 = fd.read().strip()
-        self.arch_2 = Archivist(getenv("DATATRAILS_URL"), auth_2)
-
+        self.arch_2 = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth_2,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
         # creates reciprocal subjects for arch 1 and arch 2.
         # subject 1 contains details of subject 2 to be shared
         self.subject_1, self.subject_2 = self.arch.subjects.share(

--- a/functests/execapplications.py
+++ b/functests/execapplications.py
@@ -14,7 +14,11 @@ from archivist.archivist import Archivist
 from archivist.errors import ArchivistUnauthenticatedError
 from archivist.utils import get_auth
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -54,7 +58,12 @@ class TestApplications(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
         self.display_name = f"{DISPLAY_NAME} {uuid4()}"
 
     def tearDown(self):

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -13,7 +13,11 @@ from archivist.constants import ASSET_BEHAVIOURS
 from archivist.proof_mechanism import ProofMechanism
 from archivist.utils import get_auth
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -87,7 +91,13 @@ class TestAssetCreate(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth, max_time=30)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            max_time=30,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
         self.attrs = deepcopy(ATTRS)
         self.traffic_light = deepcopy(ATTRS)
         self.traffic_light["arc_display_type"] = "Traffic light with violation camera"
@@ -233,7 +243,13 @@ class TestAssetCreateIfNotExists(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth, max_time=600)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            max_time=30,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -14,7 +14,11 @@ from archivist.archivist import Archivist
 from archivist.errors import ArchivistBadRequestError
 from archivist.utils import get_auth, get_url
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 if getenv("DATATRAILS_LOGLEVEL") is not None:
     logger.set_logger(getenv("DATATRAILS_LOGLEVEL"))
@@ -46,7 +50,12 @@ class TestAttachmentsCreate(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
         self.file_uuid: str = ""
 
         with suppress(FileNotFoundError):
@@ -208,7 +217,12 @@ class TestAttachmentstMalware(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execcompliance_policies.py
+++ b/functests/execcompliance_policies.py
@@ -19,7 +19,11 @@ from archivist.compliance_policy_requests import (
 from archivist.compliance_policy_type import CompliancePolicyType
 from archivist.utils import get_auth
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -99,7 +103,12 @@ class TestCompliancePoliciesBase(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
         self.identities = []
 
     def tearDown(self):

--- a/functests/execnotebooks.py
+++ b/functests/execnotebooks.py
@@ -14,7 +14,11 @@ from testbook import testbook
 from archivist import logger
 from archivist.archivist import Archivist
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 if getenv("DATATRAILS_LOGLEVEL") is not None:
     logger.set_logger(getenv("DATATRAILS_LOGLEVEL"))
@@ -37,7 +41,12 @@ class TestNotebooks(TestCase):
         self.client_id = getenv("DATATRAILS_APPREG_CLIENT")
         self.client_secret = getenv("DATATRAILS_APPREG_SECRET")
         self.url = getenv("DATATRAILS_URL")
-        self.arch = Archivist(self.url, (self.client_id, self.client_secret))
+        self.arch = Archivist(
+            self.url,
+            (self.client_id, self.client_secret),
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execpublicassets.py
+++ b/functests/execpublicassets.py
@@ -13,7 +13,11 @@ from archivist.constants import ASSET_BEHAVIOURS
 from archivist.timestamp import now_timestamp
 from archivist.utils import get_auth
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -84,7 +88,13 @@ class TestPublicAssetCreate(TestCase):
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
         self.url = getenv("DATATRAILS_URL")
-        self.arch = Archivist(self.url, auth, max_time=600)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            max_time=30,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
         self.attrs = deepcopy(ATTRS)
         self.traffic_light = deepcopy(ATTRS)
         self.traffic_light["arc_display_type"] = "Traffic light with violation camera"

--- a/functests/execrunner.py
+++ b/functests/execrunner.py
@@ -12,12 +12,15 @@ from archivist import logger
 from archivist.archivist import Archivist
 from archivist.utils import get_auth
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
-
 
 if getenv("DATATRAILS_LOGLEVEL") is not None:
     logger.set_logger(getenv("DATATRAILS_LOGLEVEL"))
@@ -40,7 +43,13 @@ class TestRunner(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth, max_time=300)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            max_time=30,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execsubjects.py
+++ b/functests/execsubjects.py
@@ -13,7 +13,11 @@ from archivist import logger
 from archivist.archivist import Archivist
 from archivist.utils import get_auth
 
-from .constants import TestCase
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+    TestCase,
+)
 
 if getenv("DATATRAILS_LOGLEVEL") is not None:
     logger.set_logger(getenv("DATATRAILS_LOGLEVEL"))
@@ -61,7 +65,12 @@ class TestSubjects(TestCase):
             client_secret=getenv("DATATRAILS_APPREG_SECRET"),
             client_secret_filename=getenv("DATATRAILS_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("DATATRAILS_URL"), auth)
+        self.arch = Archivist(
+            getenv("DATATRAILS_URL"),
+            auth,
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
         self.display_name = f"{DISPLAY_NAME} {uuid4()}"
 
     def tearDown(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,7 @@ valid-metaclass-classmethod-first-arg = ["cls"]
 # ignored-parents =
 
 # Maximum number of arguments for function / method.
-max-args = 6
+max-args = 8
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes = 7

--- a/unittests/constants.py
+++ b/unittests/constants.py
@@ -1,0 +1,6 @@
+"""
+Test constants
+"""
+
+PARTNER_ID_VALUE = "acmecorp"
+USER_AGENT_VALUE = "archivist-samples/v0.1.0"

--- a/unittests/testaccess_policies.py
+++ b/unittests/testaccess_policies.py
@@ -4,6 +4,7 @@ Test access policies
 
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.constants import (
     ACCESS_POLICIES_LABEL,
@@ -12,10 +13,17 @@ from archivist.constants import (
     ASSETS_LABEL,
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
+    PARTNER_ID,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistBadRequestError
 
+from .constants import (
+    PARTNER_ID_VALUE,
+    USER_AGENT_VALUE,
+)
 from .mock_response import MockResponse
 from .testassets import RESPONSE as ASSET
 
@@ -81,6 +89,67 @@ REQUEST = {
 }
 
 
+class TestAccessPoliciesPartnerID(TestCase):
+    """
+    Test Archivist AccessPolicies Create method
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        self.arch = Archivist(
+            "url",
+            "authauthauth",
+            partner_id=PARTNER_ID_VALUE,
+            user_agent=USER_AGENT_VALUE,
+        )
+
+    def tearDown(self):
+        self.arch.close()
+
+    def test_access_policies_create(self):
+        """
+        Test access_policy creation
+        """
+        with mock.patch.object(self.arch.session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+
+            access_policy = self.arch.access_policies.create(
+                PROPS, FILTERS, ACCESS_PERMISSIONS
+            )
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                args,
+                (f"url/{ROOT}/{SUBPATH}",),
+                msg="CREATE method args called incorrectly",
+            )
+            self.assertEqual(
+                kwargs,
+                {
+                    "json": REQUEST,
+                    "headers": {
+                        "authorization": "Bearer authauthauth",
+                        USER_AGENT: (
+                            f"{USER_AGENT_VALUE} "
+                            f"{USER_AGENT_PREFIX}{VERSION}"
+                        ),
+                        PARTNER_ID: PARTNER_ID_VALUE,
+                    },
+                },
+                msg="CREATE method called incorrectly",
+            )
+            self.assertEqual(
+                access_policy,
+                RESPONSE,
+                msg="CREATE method called incorrectly",
+            )
+            self.assertEqual(
+                access_policy.name,
+                ACCESS_POLICY_NAME,
+                msg="Incorrect name property",
+            )
+
+
 class TestAccessPolicies(TestCase):
     """
     Test Archivist AccessPolicies Create method
@@ -126,6 +195,7 @@ class TestAccessPolicies(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method called incorrectly",
@@ -156,6 +226,7 @@ class TestAccessPolicies(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -178,6 +249,7 @@ class TestAccessPolicies(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                     },
                 ),
@@ -207,6 +279,7 @@ class TestAccessPolicies(TestCase):
                     "json": PROPS,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="PATCH method kwargs called incorrectly",
@@ -243,6 +316,7 @@ class TestAccessPolicies(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 1},
                     },
@@ -279,6 +353,7 @@ class TestAccessPolicies(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 1,
@@ -322,6 +397,7 @@ class TestAccessPolicies(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": None,
                         },
@@ -366,6 +442,7 @@ class TestAccessPolicies(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {"display_name": "Policy display name"},
                         },
@@ -411,6 +488,7 @@ class TestAccessPolicies(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": None,
                         },
@@ -453,6 +531,7 @@ class TestAccessPolicies(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": None,
                         },

--- a/unittests/testapplications.py
+++ b/unittests/testapplications.py
@@ -4,12 +4,15 @@ Test applications
 
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.constants import (
     APPLICATIONS_LABEL,
     APPLICATIONS_REGENERATE,
     APPLICATIONS_SUBPATH,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistBadRequestError
 
@@ -94,6 +97,7 @@ class TestApplications(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -119,6 +123,7 @@ class TestApplications(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -141,6 +146,7 @@ class TestApplications(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                     },
                 ),
@@ -166,6 +172,7 @@ class TestApplications(TestCase):
                         "json": UPDATE_DATA,
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                     },
                 ),
@@ -214,6 +221,7 @@ class TestApplications(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {},
                         },
@@ -258,6 +266,7 @@ class TestApplications(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {
                                 "display_name": "Application display name",
@@ -287,6 +296,7 @@ class TestApplications(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "json": None,
                     },

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -6,8 +6,14 @@ from copy import copy
 from os import environ
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
-from archivist.constants import HEADERS_RETRY_AFTER, HEADERS_TOTAL_COUNT
+from archivist.constants import (
+    HEADERS_RETRY_AFTER,
+    HEADERS_TOTAL_COUNT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
+)
 from archivist.errors import (
     ArchivistBadRequestError,
     ArchivistError,
@@ -268,6 +274,7 @@ class TestArchivistPatch(TestArchivistMethods):
                     "json": request,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="POST method kwargs called incorrectly",
@@ -295,7 +302,10 @@ class TestArchivistPatch(TestArchivistMethods):
             self.arch.patch(
                 "path/path/entity/xxxx",
                 request,
-                headers={"headerfield1": "headervalue1"},
+                headers={
+                    "headerfield1": "headervalue1",
+                    USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                },
             )
             args, kwargs = mock_patch.call_args
             self.assertEqual(
@@ -310,6 +320,7 @@ class TestArchivistPatch(TestArchivistMethods):
                     "headers": {
                         "authorization": "Bearer authauthauth",
                         "headerfield1": "headervalue1",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="PATCH method kwargs called incorrectly",
@@ -386,6 +397,7 @@ class TestArchivistPatch(TestArchivistMethods):
                     "json": request,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="PATCH method kwargs called incorrectly",

--- a/unittests/testarchivistdelete.py
+++ b/unittests/testarchivistdelete.py
@@ -4,8 +4,13 @@ Test archivist delete
 
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
-from archivist.constants import HEADERS_RETRY_AFTER
+from archivist.constants import (
+    HEADERS_RETRY_AFTER,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
+)
 from archivist.errors import (
     ArchivistNotFoundError,
     ArchivistTooManyRequestsError,
@@ -49,6 +54,7 @@ class TestArchivistDelete(TestArchivistMethods):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                     },
                 ),
@@ -72,7 +78,10 @@ class TestArchivistDelete(TestArchivistMethods):
             mock_delete.return_value = MockResponse(200)
             self.arch.delete(
                 "path/path/id/xxxxxxxx",
-                headers={"headerfield1": "headervalue1"},
+                headers={
+                    "headerfield1": "headervalue1",
+                    USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                },
             )
             self.assertEqual(
                 tuple(mock_delete.call_args),
@@ -82,6 +91,7 @@ class TestArchivistDelete(TestArchivistMethods):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             "headerfield1": "headervalue1",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                     },
                 ),
@@ -97,7 +107,10 @@ class TestArchivistDelete(TestArchivistMethods):
             with self.assertRaises(ArchivistTooManyRequestsError):
                 self.arch.delete(
                     "path/path/id/xxxxxxxx",
-                    headers={"headerfield1": "headervalue1"},
+                    headers={
+                        "headerfield1": "headervalue1",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                    },
                 )
 
     def test_delete_with_429_retry_and_fail(self):
@@ -144,6 +157,7 @@ class TestArchivistDelete(TestArchivistMethods):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                     },
                 ),

--- a/unittests/testarchivistget.py
+++ b/unittests/testarchivistget.py
@@ -5,8 +5,13 @@ Test archivist get
 from io import BytesIO
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
-from archivist.constants import HEADERS_RETRY_AFTER
+from archivist.constants import (
+    HEADERS_RETRY_AFTER,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
+)
 from archivist.errors import (
     ArchivistNotFoundError,
     ArchivistTooManyRequestsError,
@@ -50,6 +55,7 @@ class TestArchivistGet(TestArchivistMethods):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -84,7 +90,10 @@ class TestArchivistGet(TestArchivistMethods):
             mock_get.return_value = MockResponse(200)
             self.arch.get(
                 "path/path/id/xxxxxxxx",
-                headers={"headerfield1": "headervalue1"},
+                headers={
+                    "headerfield1": "headervalue1",
+                    USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                },
             )
             self.assertEqual(
                 tuple(mock_get.call_args),
@@ -94,6 +103,7 @@ class TestArchivistGet(TestArchivistMethods):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             "headerfield1": "headervalue1",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -110,7 +120,10 @@ class TestArchivistGet(TestArchivistMethods):
             with self.assertRaises(ArchivistTooManyRequestsError):
                 self.arch.get(
                     "path/path/id/xxxxxxxx",
-                    headers={"headerfield1": "headervalue1"},
+                    headers={
+                        "headerfield1": "headervalue1",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                    },
                 )
 
     def test_get_with_429_retry_and_fail(self):
@@ -157,6 +170,7 @@ class TestArchivistGet(TestArchivistMethods):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -206,6 +220,7 @@ class TestArchivistGetFile(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "stream": True,
                             "params": None,
@@ -298,6 +313,7 @@ class TestArchivistGetFile(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "stream": True,
                             "params": None,

--- a/unittests/testarchivistlist.py
+++ b/unittests/testarchivistlist.py
@@ -5,7 +5,13 @@ Test archivist list
 from os import environ
 from unittest import mock
 
-from archivist.constants import HEADERS_RETRY_AFTER, HEADERS_TOTAL_COUNT
+from archivist.about import __version__ as VERSION
+from archivist.constants import (
+    HEADERS_RETRY_AFTER,
+    HEADERS_TOTAL_COUNT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
+)
 from archivist.errors import (
     ArchivistBadFieldError,
     ArchivistBadRequestError,
@@ -56,6 +62,7 @@ class TestArchivistList(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": None,
                         },
@@ -112,7 +119,10 @@ class TestArchivistList(TestArchivistMethods):
                 self.arch.list(
                     "path/path",
                     "things",
-                    headers={"headerfield1": "headervalue1"},
+                    headers={
+                        "headerfield1": "headervalue1",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                    },
                 )
             )
             self.assertEqual(
@@ -129,6 +139,7 @@ class TestArchivistList(TestArchivistMethods):
                             "headers": {
                                 "authorization": "Bearer authauthauth",
                                 "headerfield1": "headervalue1",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": None,
                         },
@@ -169,6 +180,7 @@ class TestArchivistList(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {"paramsfield1": "paramsvalue1"},
                         },
@@ -213,6 +225,7 @@ class TestArchivistList(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {"page_size": 2},
                         },
@@ -279,6 +292,7 @@ class TestArchivistList(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": paging[i],
                         },
@@ -350,6 +364,7 @@ class TestArchivistList(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": paging[i],
                         },
@@ -431,6 +446,7 @@ class TestArchivistList(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": None,
                         },

--- a/unittests/testarchivistpost.py
+++ b/unittests/testarchivistpost.py
@@ -5,8 +5,13 @@ Test archivist post
 from io import BytesIO
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
-from archivist.constants import HEADERS_RETRY_AFTER
+from archivist.constants import (
+    HEADERS_RETRY_AFTER,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
+)
 from archivist.errors import (
     ArchivistBadRequestError,
     ArchivistTooManyRequestsError,
@@ -56,6 +61,7 @@ class TestArchivistPost(TestArchivistMethods):
                     "json": request,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="POST method kwargs called incorrectly",
@@ -133,6 +139,7 @@ class TestArchivistPost(TestArchivistMethods):
                     "json": request,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="POST method kwargs called incorrectly",
@@ -148,7 +155,10 @@ class TestArchivistPost(TestArchivistMethods):
             self.arch.post(
                 "path/path",
                 request,
-                headers={"headerfield1": "headervalue1"},
+                headers={
+                    "headerfield1": "headervalue1",
+                    USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                },
             )
             args, kwargs = mock_post.call_args
             self.assertEqual(
@@ -163,6 +173,7 @@ class TestArchivistPost(TestArchivistMethods):
                     "headers": {
                         "authorization": "Bearer authauthauth",
                         "headerfield1": "headervalue1",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="POST method kwargs called incorrectly",
@@ -453,7 +464,9 @@ class TestArchivistPostWithoutAuth(TestCase):
                 kwargs,
                 {
                     "json": request,
-                    "headers": {},
+                    "headers": {
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                    },
                 },
                 msg="POST method kwargs called incorrectly",
             )

--- a/unittests/testarchivistsignature.py
+++ b/unittests/testarchivistsignature.py
@@ -5,6 +5,11 @@ Test archivist signature
 from os import environ
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
+from archivist.constants import (
+    USER_AGENT,
+    USER_AGENT_PREFIX,
+)
 from archivist.errors import (
     ArchivistBadFieldError,
     ArchivistDuplicateError,
@@ -50,6 +55,7 @@ class TestArchivistSignature(TestArchivistMethods):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {"field1": "value1", "page_size": 2},
                         },

--- a/unittests/testassetattachments.py
+++ b/unittests/testassetattachments.py
@@ -5,6 +5,7 @@ Test restricted asset attachments
 from io import BytesIO
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.constants import (
     ASSETATTACHMENTS_LABEL,
@@ -12,6 +13,8 @@ from archivist.constants import (
     ASSETS_LABEL,
     ATTACHMENTS_LABEL,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 
 from .mock_response import MockResponse
@@ -134,6 +137,7 @@ class TestAssetAttachmentsDownload(TestAssetAttachmentsBase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": expected_params,
                         "stream": True,
@@ -203,6 +207,7 @@ class TestAssetAttachmentsInfo(TestAssetAttachmentsBase):
                 {
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                     "params": None,
                 },

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -2,15 +2,18 @@
 Test assets
 """
 
-from copy import copy
+from copy import copy, deepcopy
 from logging import getLogger
 from os import environ
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ASSETS_LABEL,
     ASSETS_SUBPATH,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistNotFoundError, ArchivistUnconfirmedError
 from archivist.logger import set_logger
@@ -93,9 +96,11 @@ class TestAssetsCreate(TestAssetsBase):
                 (f"url/{ROOT}/{ASSETS_SUBPATH}/{ASSETS_LABEL}",),
                 msg="CREATE method args called incorrectly",
             )
+            req_kwargs = deepcopy(REQUEST_KWARGS)
+            req_kwargs["headers"][USER_AGENT] = f"{USER_AGENT_PREFIX}{VERSION}"
             self.assertEqual(
                 kwargs,
-                REQUEST_KWARGS,
+                req_kwargs,
                 msg="CREATE method kwargs called incorrectly",
             )
             self.assertEqual(
@@ -130,9 +135,11 @@ class TestAssetsCreate(TestAssetsBase):
                 (f"url/{ROOT}/{ASSETS_SUBPATH}/{ASSETS_LABEL}",),
                 msg="CREATE method args called incorrectly",
             )
+            req_kwargs = deepcopy(REQUEST_KWARGS_MERKLE_LOG)
+            req_kwargs["headers"][USER_AGENT] = f"{USER_AGENT_PREFIX}{VERSION}"
             self.assertEqual(
                 kwargs,
-                REQUEST_KWARGS_MERKLE_LOG,
+                req_kwargs,
                 msg="CREATE method kwargs called incorrectly",
             )
             self.assertEqual(
@@ -166,9 +173,11 @@ class TestAssetsCreate(TestAssetsBase):
                 (f"url/{ROOT}/{ASSETS_SUBPATH}/{ASSETS_LABEL}",),
                 msg="CREATE method args called incorrectly",
             )
+            req_kwargs = deepcopy(REQUEST_FIXTURES_KWARGS)
+            req_kwargs["headers"][USER_AGENT] = f"{USER_AGENT_PREFIX}{VERSION}"
             self.assertEqual(
                 kwargs,
-                REQUEST_FIXTURES_KWARGS,
+                req_kwargs,
                 msg="CREATE method kwargs called incorrectly",
             )
             self.assertEqual(
@@ -342,6 +351,7 @@ class TestAssetsCreateIfNotExists(TestAssetsBase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "attributes.arc_namespace": "namespace",
@@ -399,6 +409,7 @@ class TestAssetsCreateIfNotExists(TestAssetsBase):
                 (f"url/{ROOT}/{ASSETS_SUBPATH}/{ASSETS_LABEL}",),
                 msg="CREATE method args called incorrectly",
             )
+            req_kwargs["headers"][USER_AGENT] = f"{USER_AGENT_PREFIX}{VERSION}"
             self.assertEqual(
                 kwargs,
                 req_kwargs,

--- a/unittests/testassetslist.py
+++ b/unittests/testassetslist.py
@@ -6,8 +6,11 @@ from logging import getLogger
 from os import environ
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.logger import set_logger
 
@@ -66,6 +69,7 @@ class TestAssetsList(TestAssetsBase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {},
                         },
@@ -113,6 +117,7 @@ class TestAssetsList(TestAssetsBase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {
                                 "confirmation_status": "CONFIRMED",
@@ -149,6 +154,7 @@ class TestAssetsList(TestAssetsBase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 2},
                     },

--- a/unittests/testassetsread.py
+++ b/unittests/testassetsread.py
@@ -6,10 +6,13 @@ from logging import getLogger
 from os import environ
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistBadFieldError
 from archivist.logger import set_logger
@@ -125,6 +128,7 @@ class TestAssetsCount(TestAssetsBase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 1},
                     },
@@ -158,6 +162,7 @@ class TestAssetsCount(TestAssetsBase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 1,
@@ -192,6 +197,7 @@ class TestAssetsCount(TestAssetsBase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 1,

--- a/unittests/testassetswait.py
+++ b/unittests/testassetswait.py
@@ -6,10 +6,13 @@ from logging import getLogger
 from os import environ
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistNotFoundError, ArchivistUnconfirmedError
 from archivist.logger import set_logger
@@ -91,6 +94,7 @@ class TestAssetsWait(TestAssetsBase):
                             "headers": {
                                 "authorization": "Bearer authauthauth",
                                 HEADERS_REQUEST_TOTAL_COUNT: "true",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": status[i],
                         },

--- a/unittests/testattachments.py
+++ b/unittests/testattachments.py
@@ -5,11 +5,14 @@ Test attachments
 from io import BytesIO
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.constants import (
     ATTACHMENTS_LABEL,
     ATTACHMENTS_SUBPATH,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 
 from .mock_response import MockResponse
@@ -301,6 +304,7 @@ class TestAttachmentsDownload(TestAttachmentsBase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": expected_params,
                         "stream": True,
@@ -370,6 +374,7 @@ class TestAttachmentsInfo(TestAttachmentsBase):
                 {
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                     "params": None,
                 },

--- a/unittests/testcompliance.py
+++ b/unittests/testcompliance.py
@@ -6,12 +6,15 @@ from logging import getLogger
 from os import environ
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.constants import (
     COMPLIANCE_LABEL,
     COMPLIANCE_POLICIES_LABEL,
     COMPLIANCE_SUBPATH,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.logger import set_logger
 
@@ -131,6 +134,7 @@ class TestCompliance(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": None,
                         },

--- a/unittests/testcompliance_policies.py
+++ b/unittests/testcompliance_policies.py
@@ -4,6 +4,7 @@ Test compliance policies
 
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.compliance_policies import (
     CompliancePolicy,
@@ -17,6 +18,8 @@ from archivist.constants import (
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistBadRequestError
 
@@ -123,6 +126,7 @@ class TestCompliancePolicies(TestCase):
                     "json": SINCE_REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -148,6 +152,7 @@ class TestCompliancePolicies(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -170,6 +175,7 @@ class TestCompliancePolicies(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                     },
                 ),
@@ -207,6 +213,7 @@ class TestCompliancePolicies(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 1},
                     },
@@ -243,6 +250,7 @@ class TestCompliancePolicies(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 1, "compliance_type": "SINCE"},
                     },
@@ -283,6 +291,7 @@ class TestCompliancePolicies(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {},
                         },
@@ -327,6 +336,7 @@ class TestCompliancePolicies(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {"compliance_type": "SINCE"},
                         },
@@ -360,6 +370,7 @@ class TestCompliancePolicies(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 2},
                     },

--- a/unittests/testevents.py
+++ b/unittests/testevents.py
@@ -4,11 +4,14 @@ Test events
 
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ASSETS_LABEL,
     ASSETS_SUBPATH,
     EVENTS_LABEL,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.events import Event
 
@@ -111,6 +114,7 @@ class TestEventsRead(TestEventsBase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },

--- a/unittests/testeventscount.py
+++ b/unittests/testeventscount.py
@@ -4,6 +4,7 @@ Test events count
 
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ASSETS_LABEL,
     ASSETS_SUBPATH,
@@ -12,6 +13,8 @@ from archivist.constants import (
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 
 from .mock_response import MockResponse
@@ -65,6 +68,7 @@ class TestEventsCount(TestEventsBase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 1},
                     },
@@ -105,6 +109,7 @@ class TestEventsCount(TestEventsBase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 1, "confirmation_status": "CONFIRMED"},
                     },
@@ -143,6 +148,7 @@ class TestEventsCount(TestEventsBase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 1,
@@ -183,6 +189,7 @@ class TestEventsCount(TestEventsBase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 1,

--- a/unittests/testeventscreate.py
+++ b/unittests/testeventscreate.py
@@ -4,11 +4,14 @@ Test events create
 
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ASSETS_LABEL,
     ASSETS_SUBPATH,
     EVENTS_LABEL,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import (
     ArchivistUnconfirmedError,
@@ -90,6 +93,7 @@ class TestEventsCreate(TestEventsBase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -133,6 +137,7 @@ class TestEventsCreate(TestEventsBase):
                     "json": REQUEST_WITH_ATTACHMENTS,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -179,6 +184,7 @@ class TestEventsCreate(TestEventsBase):
                     "json": REQUEST_WITH_SBOMATTACHMENT,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -222,6 +228,7 @@ class TestEventsCreate(TestEventsBase):
                     "json": REQUEST_WITH_LOCATION,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -262,6 +269,7 @@ class TestEventsCreate(TestEventsBase):
                     "json": REQUEST_WITH_LOCATION,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -304,6 +312,7 @@ class TestEventsCreate(TestEventsBase):
                     "json": REQUEST_WITH_ASSET_ATTRS,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",

--- a/unittests/testeventslist.py
+++ b/unittests/testeventslist.py
@@ -4,12 +4,15 @@ Test events list
 
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ASSETS_LABEL,
     ASSETS_SUBPATH,
     ASSETS_WILDCARD,
     EVENTS_LABEL,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 
 from .mock_response import MockResponse
@@ -69,6 +72,7 @@ class TestEventsList(TestEventsBase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {},
                         },
@@ -123,6 +127,7 @@ class TestEventsList(TestEventsBase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {
                                 "confirmation_status": "CONFIRMED",
@@ -179,6 +184,7 @@ class TestEventsList(TestEventsBase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {
                                 "confirmation_status": "CONFIRMED",
@@ -221,6 +227,7 @@ class TestEventsList(TestEventsBase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 2},
                     },

--- a/unittests/testeventsread.py
+++ b/unittests/testeventsread.py
@@ -4,11 +4,14 @@ Test events read
 
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ASSETS_LABEL,
     ASSETS_SUBPATH,
     EVENTS_LABEL,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistBadFieldError
 
@@ -54,6 +57,7 @@ class TestEventsRead(TestEventsBase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },

--- a/unittests/testeventswait.py
+++ b/unittests/testeventswait.py
@@ -4,6 +4,7 @@ Test events wait
 
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ASSETS_SUBPATH,
     ASSETS_WILDCARD,
@@ -11,6 +12,8 @@ from archivist.constants import (
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import (
     ArchivistNotFoundError,
@@ -86,6 +89,7 @@ class TestEventsWait(TestEventsBase):
                             "headers": {
                                 "authorization": "Bearer authauthauth",
                                 HEADERS_REQUEST_TOTAL_COUNT: "true",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": status[i],
                         },

--- a/unittests/testlocations.py
+++ b/unittests/testlocations.py
@@ -4,6 +4,7 @@ Test locations
 
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.constants import (
     HEADERS_REQUEST_TOTAL_COUNT,
@@ -11,6 +12,8 @@ from archivist.constants import (
     LOCATIONS_LABEL,
     LOCATIONS_SUBPATH,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistBadRequestError, ArchivistNotFoundError
 from archivist.locations import Location
@@ -188,6 +191,7 @@ class TestLocations(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -234,6 +238,7 @@ class TestLocations(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 2,
@@ -281,6 +286,7 @@ class TestLocations(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -324,6 +330,7 @@ class TestLocations(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -344,6 +351,7 @@ class TestLocations(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -382,6 +390,7 @@ class TestLocations(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 1},
                     },
@@ -418,6 +427,7 @@ class TestLocations(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 1,
@@ -452,6 +462,7 @@ class TestLocations(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 1,
@@ -495,6 +506,7 @@ class TestLocations(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {},
                         },
@@ -540,6 +552,7 @@ class TestLocations(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {
                                 "attributes.director": "John Smith",
@@ -576,6 +589,7 @@ class TestLocations(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 2},
                     },

--- a/unittests/testpublicassetattachments.py
+++ b/unittests/testpublicassetattachments.py
@@ -7,6 +7,7 @@ from logging import getLogger
 from os import environ
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivistpublic import ArchivistPublic
 from archivist.constants import (
     ASSETATTACHMENTS_LABEL,
@@ -14,6 +15,8 @@ from archivist.constants import (
     ASSETS_LABEL,
     ATTACHMENTS_LABEL,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.logger import set_logger
 
@@ -142,7 +145,9 @@ class TestPublicAssetAttachmentsDownload(TestPublicAssetAttachmentsBase):
                 self.assertEqual(
                     kwargs,
                     {
-                        "headers": {},
+                        "headers": {
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                        },
                         "params": expected_params,
                         "stream": True,
                     },
@@ -209,7 +214,9 @@ class TestPublicAssetAttachmentsInfo(TestPublicAssetAttachmentsBase):
             self.assertEqual(
                 kwargs,
                 {
-                    "headers": {},
+                    "headers": {
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                    },
                     "params": None,
                 },
                 msg="INFO method called incorrectly",

--- a/unittests/testpublicassetsread.py
+++ b/unittests/testpublicassetsread.py
@@ -6,8 +6,11 @@ from logging import getLogger
 from os import environ
 from unittest import mock
 
+from archivist.about import __version__ as VERSION
 from archivist.constants import (
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.logger import set_logger
 
@@ -64,7 +67,9 @@ class TestPublicAssetsRead(TestPublicAssetsBase):
             self.assertEqual(
                 kwargs,
                 {
-                    "headers": {},
+                    "headers": {
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                    },
                     "params": None,
                 },
                 msg="GET method kwargs called incorrectly",

--- a/unittests/testpublicevents.py
+++ b/unittests/testpublicevents.py
@@ -6,6 +6,7 @@ from logging import getLogger
 from os import environ
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivistpublic import ArchivistPublic
 from archivist.constants import (
     EVENTS_LABEL,
@@ -13,6 +14,8 @@ from archivist.constants import (
     HEADERS_TOTAL_COUNT,
     PUBLICASSETS_LABEL,
     ROOT,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.logger import set_logger
 
@@ -82,7 +85,9 @@ class TestPublicEvents(TestCase):
                         ),
                     ),
                     {
-                        "headers": {},
+                        "headers": {
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                        },
                         "params": None,
                     },
                 ),
@@ -113,7 +118,9 @@ class TestPublicEvents(TestCase):
                         ),
                     ),
                     {
-                        "headers": {},
+                        "headers": {
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                        },
                         "params": None,
                     },
                 ),
@@ -161,6 +168,7 @@ class TestPublicEvents(TestCase):
                     {
                         "headers": {
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "asset_attributes.external_container": "assets/xxxx",
@@ -208,6 +216,7 @@ class TestPublicEvents(TestCase):
                     {
                         "headers": {
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "asset_attributes.external_container": "assets/xxxx",
@@ -256,7 +265,9 @@ class TestPublicEvents(TestCase):
                             ),
                         ),
                         {
-                            "headers": {},
+                            "headers": {
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                            },
                             "params": {},
                         },
                     ),
@@ -300,7 +311,9 @@ class TestPublicEvents(TestCase):
                             ),
                         ),
                         {
-                            "headers": {},
+                            "headers": {
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                            },
                             "params": {},
                         },
                     ),
@@ -337,7 +350,9 @@ class TestPublicEvents(TestCase):
                         ),
                     ),
                     {
-                        "headers": {},
+                        "headers": {
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                        },
                         "params": {"page_size": 2},
                     },
                 ),

--- a/unittests/testpublicget.py
+++ b/unittests/testpublicget.py
@@ -5,8 +5,13 @@ Test public get
 from io import BytesIO
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivistpublic import ArchivistPublic
-from archivist.constants import HEADERS_RETRY_AFTER
+from archivist.constants import (
+    HEADERS_RETRY_AFTER,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
+)
 from archivist.errors import (
     ArchivistNotFoundError,
     ArchivistTooManyRequestsError,
@@ -48,7 +53,7 @@ class TestPublicGet(TestPublicMethods):
                 (
                     ("https://path/path/entity/xxxxxxxx",),
                     {
-                        "headers": {},
+                        "headers": {USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}"},
                         "params": None,
                     },
                 ),
@@ -82,7 +87,10 @@ class TestPublicGet(TestPublicMethods):
             mock_get.return_value = MockResponse(200)
             self.public.get(
                 "https://path/path/id/xxxxxxxx",
-                headers={"headerfield1": "headervalue1"},
+                headers={
+                    "headerfield1": "headervalue1",
+                    USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                },
             )
             self.assertEqual(
                 tuple(mock_get.call_args),
@@ -91,6 +99,7 @@ class TestPublicGet(TestPublicMethods):
                     {
                         "headers": {
                             "headerfield1": "headervalue1",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -107,7 +116,10 @@ class TestPublicGet(TestPublicMethods):
             with self.assertRaises(ArchivistTooManyRequestsError):
                 self.public.get(
                     "https://path/path/id/xxxxxxxx",
-                    headers={"headerfield1": "headervalue1"},
+                    headers={
+                        "headerfield1": "headervalue1",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                    },
                 )
 
     def test_get_with_429_retry_and_fail(self):
@@ -152,7 +164,9 @@ class TestPublicGet(TestPublicMethods):
                 (
                     ("https://path/path/entity/xxxxxxxx",),
                     {
-                        "headers": {},
+                        "headers": {
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                        },
                         "params": None,
                     },
                 ),
@@ -199,7 +213,9 @@ class TestPublicGetFile(TestPublicMethods):
                     (
                         ("https://path/path/entity/xxxxxxxx",),
                         {
-                            "headers": {},
+                            "headers": {
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                            },
                             "stream": True,
                             "params": None,
                         },
@@ -289,7 +305,9 @@ class TestPublicGetFile(TestPublicMethods):
                     (
                         ("path/path/entity/xxxxxxxx",),
                         {
-                            "headers": {},
+                            "headers": {
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
+                            },
                             "stream": True,
                             "params": None,
                         },

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -5,6 +5,7 @@ Test subjects
 from os import environ
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.constants import (
     HEADERS_REQUEST_TOTAL_COUNT,
@@ -12,6 +13,8 @@ from archivist.constants import (
     ROOT,
     SUBJECTS_LABEL,
     SUBJECTS_SUBPATH,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.errors import ArchivistBadRequestError, ArchivistUnconfirmedError
 from archivist.logger import set_logger
@@ -138,6 +141,7 @@ class TestSubjects(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -181,6 +185,7 @@ class TestSubjects(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -202,6 +207,7 @@ class TestSubjects(TestCase):
                     "json": REQUEST2,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -232,6 +238,7 @@ class TestSubjects(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -267,6 +274,7 @@ class TestSubjects(TestCase):
                     "json": REQUEST,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="CREATE method kwargs called incorrectly",
@@ -318,6 +326,7 @@ class TestSubjects(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": None,
                     },
@@ -340,6 +349,7 @@ class TestSubjects(TestCase):
                     {
                         "headers": {
                             "authorization": "Bearer authauthauth",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                     },
                 ),
@@ -369,6 +379,7 @@ class TestSubjects(TestCase):
                     "json": UPDATE,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="PATCH method kwargs called incorrectly",
@@ -405,6 +416,7 @@ class TestSubjects(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {"page_size": 1},
                     },
@@ -441,6 +453,7 @@ class TestSubjects(TestCase):
                         "headers": {
                             "authorization": "Bearer authauthauth",
                             HEADERS_REQUEST_TOTAL_COUNT: "true",
+                            USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                         },
                         "params": {
                             "page_size": 1,
@@ -484,6 +497,7 @@ class TestSubjects(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {},
                         },
@@ -528,6 +542,7 @@ class TestSubjects(TestCase):
                         {
                             "headers": {
                                 "authorization": "Bearer authauthauth",
+                                USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                             },
                             "params": {"display_name": "Subject display name"},
                         },

--- a/unittests/testtenancies.py
+++ b/unittests/testtenancies.py
@@ -6,12 +6,15 @@ from logging import getLogger
 from os import environ
 from unittest import TestCase, mock
 
+from archivist.about import __version__ as VERSION
 from archivist.archivist import Archivist
 from archivist.constants import (
     ROOT,
     TENANCIES_LABEL,
     TENANCIES_PREFIX,
     TENANCIES_SUBPATH,
+    USER_AGENT,
+    USER_AGENT_PREFIX,
 )
 from archivist.logger import set_logger
 
@@ -84,6 +87,7 @@ class TestTenanciesRead(TestTenanciesBase):
                     "params": None,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="GET method kwargs called incorrectly",
@@ -114,6 +118,7 @@ class TestTenanciesRead(TestTenanciesBase):
                     "params": None,
                     "headers": {
                         "authorization": "Bearer authauthauth",
+                        USER_AGENT: f"{USER_AGENT_PREFIX}{VERSION}",
                     },
                 },
                 msg="GET method kwargs called incorrectly",


### PR DESCRIPTION
Add DataTrails-User-Agent and DataTrails-Partner-ID headers.

Typical header values when called from datatrails-samples (for example will be:

>{
>    "DataTrails-Partner-ID": "acmecorp",
>    "DataTrails-User-Agent": "datatrails-samples/v0.17.2 pysdk/v0.13.2"
>}

[test_results.txt](https://github.com/user-attachments/files/16099313/test_results.txt)


Fixes [AB#9572](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9572)