### PR TITLE
Accumulate user_agent

### DIFF
--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -203,15 +203,17 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
     @property
     def Public(self) -> ArchivistPublic:  # pylint: disable=invalid-name
         """Get a Public instance"""
-        return ArchivistPublic(
+        arch = ArchivistPublic(
             fixtures=deepcopy(self._fixtures),
             verify=self._verify,
             max_time=self._max_time,
             partner_id=self._partner_id,
         )
+        arch._user_agent = self._user_agent  # pylint: disable=protected-access
+        return arch
 
     def __copy__(self) -> "Archivist":
-        return Archivist(
+        arch = Archivist(
             self._url,
             self.auth,
             fixtures=deepcopy(self._fixtures),
@@ -219,6 +221,8 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
             max_time=self._max_time,
             partner_id=self._partner_id,
         )
+        arch._user_agent = self._user_agent
+        return arch
 
     def _add_headers(self, headers: "dict[str,str]|None") -> "dict[str,Any]":
         newheaders = super()._add_headers(headers)

--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -109,14 +109,12 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
         verify: bool = True,
         max_time: float = MAX_TIME,
         partner_id: str = "",
-        user_agent: str = "",
     ):
         super().__init__(
             fixtures=fixtures,
             verify=verify,
             max_time=max_time,
             partner_id=partner_id,
-            user_agent=user_agent,
         )
 
         if isinstance(auth, tuple):
@@ -209,6 +207,7 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
             fixtures=deepcopy(self._fixtures),
             verify=self._verify,
             max_time=self._max_time,
+            partner_id=self._partner_id,
         )
 
     def __copy__(self) -> "Archivist":
@@ -219,7 +218,6 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
             verify=self._verify,
             max_time=self._max_time,
             partner_id=self._partner_id,
-            user_agent=self._user_agent,
         )
 
     def _add_headers(self, headers: "dict[str,str]|None") -> "dict[str,Any]":

--- a/archivist/archivistpublic.py
+++ b/archivist/archivistpublic.py
@@ -87,7 +87,6 @@ class ArchivistPublic:  # pylint: disable=too-many-instance-attributes
         verify: bool = True,
         max_time: float = MAX_TIME,
         partner_id: str = "",
-        user_agent: str = "",
     ):
         self._verify = verify
         self._response_ring_buffer = deque(maxlen=self.RING_BUFFER_MAX_LEN)
@@ -95,7 +94,7 @@ class ArchivistPublic:  # pylint: disable=too-many-instance-attributes
         self._max_time = max_time
         self._fixtures = fixtures or {}
         self._partner_id = partner_id
-        self._user_agent = user_agent
+        self._user_agent = f"{USER_AGENT_PREFIX}{self.version}"
 
         # Type hints for IDE autocomplete, keep in sync with CLIENTS map above
         self.assets: _AssetsPublic
@@ -171,8 +170,13 @@ class ArchivistPublic:  # pylint: disable=too-many-instance-attributes
 
     @property
     def user_agent(self) -> str:
-        """str: Returns partner id if set when initialising an instance of this class"""
+        """str: Returns user agent"""
         return self._user_agent
+
+    @user_agent.setter
+    def user_agent(self, value):
+        """str: Prepends user agent to user_agent property"""
+        self._user_agent = f"{value} {self.user_agent}"
 
     @property
     def fixtures(self) -> "dict[str, Any]":
@@ -189,18 +193,12 @@ class ArchivistPublic:  # pylint: disable=too-many-instance-attributes
             fixtures=deepcopy(self._fixtures),
             verify=self._verify,
             max_time=self._max_time,
+            partner_id=self.partner_id,
         )
 
     def _add_headers(self, headers: "dict[str, str]|None") -> "dict[str, str]":
         newheaders = {**headers} if headers is not None else {}
-        u = self.user_agent
-        if u:
-            newheaders[USER_AGENT] = (
-                f"{self.user_agent} "
-                f"{USER_AGENT_PREFIX}{self.version}"
-            )
-        else:
-            newheaders[USER_AGENT] = f"{USER_AGENT_PREFIX}{self.version}"
+        newheaders[USER_AGENT] = self.user_agent
 
         p = self.partner_id
         if p:

--- a/archivist/archivistpublic.py
+++ b/archivist/archivistpublic.py
@@ -189,12 +189,14 @@ class ArchivistPublic:  # pylint: disable=too-many-instance-attributes
         self._fixtures = _deepmerge(self._fixtures, fixtures)
 
     def __copy__(self):
-        return ArchivistPublic(
+        arch = ArchivistPublic(
             fixtures=deepcopy(self._fixtures),
             verify=self._verify,
             max_time=self._max_time,
             partner_id=self.partner_id,
         )
+        arch._user_agent = self._user_agent
+        return arch
 
     def _add_headers(self, headers: "dict[str, str]|None") -> "dict[str, str]":
         newheaders = {**headers} if headers is not None else {}

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -125,8 +125,8 @@ class TestAccessPoliciesBase(TestCase):
             getenv("DATATRAILS_URL"),
             auth,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
 
         # these are for access_policies
         self.ac_props = deepcopy(PROPS)
@@ -311,8 +311,8 @@ class TestAccessPoliciesShare(TestAccessPoliciesBase):
             getenv("DATATRAILS_URL"),
             auth_2,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
         # creates reciprocal subjects for arch 1 and arch 2.
         # subject 1 contains details of subject 2 to be shared
         self.subject_1, self.subject_2 = self.arch.subjects.share(

--- a/functests/execapplications.py
+++ b/functests/execapplications.py
@@ -62,8 +62,8 @@ class TestApplications(TestCase):
             getenv("DATATRAILS_URL"),
             auth,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
         self.display_name = f"{DISPLAY_NAME} {uuid4()}"
 
     def tearDown(self):

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -96,8 +96,8 @@ class TestAssetCreate(TestCase):
             auth,
             max_time=30,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
         self.attrs = deepcopy(ATTRS)
         self.traffic_light = deepcopy(ATTRS)
         self.traffic_light["arc_display_type"] = "Traffic light with violation camera"
@@ -248,8 +248,8 @@ class TestAssetCreateIfNotExists(TestCase):
             auth,
             max_time=30,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -54,8 +54,8 @@ class TestAttachmentsCreate(TestCase):
             getenv("DATATRAILS_URL"),
             auth,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
         self.file_uuid: str = ""
 
         with suppress(FileNotFoundError):
@@ -221,8 +221,8 @@ class TestAttachmentstMalware(TestCase):
             getenv("DATATRAILS_URL"),
             auth,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execcompliance_policies.py
+++ b/functests/execcompliance_policies.py
@@ -107,8 +107,8 @@ class TestCompliancePoliciesBase(TestCase):
             getenv("DATATRAILS_URL"),
             auth,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
         self.identities = []
 
     def tearDown(self):

--- a/functests/execnotebooks.py
+++ b/functests/execnotebooks.py
@@ -45,8 +45,8 @@ class TestNotebooks(TestCase):
             self.url,
             (self.client_id, self.client_secret),
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execpublicassets.py
+++ b/functests/execpublicassets.py
@@ -93,8 +93,8 @@ class TestPublicAssetCreate(TestCase):
             auth,
             max_time=30,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
         self.attrs = deepcopy(ATTRS)
         self.traffic_light = deepcopy(ATTRS)
         self.traffic_light["arc_display_type"] = "Traffic light with violation camera"

--- a/functests/execrunner.py
+++ b/functests/execrunner.py
@@ -48,8 +48,8 @@ class TestRunner(TestCase):
             auth,
             max_time=30,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execsubjects.py
+++ b/functests/execsubjects.py
@@ -69,8 +69,8 @@ class TestSubjects(TestCase):
             getenv("DATATRAILS_URL"),
             auth,
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
         self.display_name = f"{DISPLAY_NAME} {uuid4()}"
 
     def tearDown(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,7 @@ valid-metaclass-classmethod-first-arg = ["cls"]
 # ignored-parents =
 
 # Maximum number of arguments for function / method.
-max-args = 8
+max-args = 7
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes = 7

--- a/unittests/constants.py
+++ b/unittests/constants.py
@@ -3,4 +3,4 @@ Test constants
 """
 
 PARTNER_ID_VALUE = "acmecorp"
-USER_AGENT_VALUE = "archivist-samples/v0.1.0"
+USER_AGENT_VALUE = "samples/v0.1.0"

--- a/unittests/testaccess_policies.py
+++ b/unittests/testaccess_policies.py
@@ -101,8 +101,8 @@ class TestAccessPoliciesPartnerID(TestCase):
             "url",
             "authauthauth",
             partner_id=PARTNER_ID_VALUE,
-            user_agent=USER_AGENT_VALUE,
         )
+        self.arch.user_agent = USER_AGENT_VALUE
 
     def tearDown(self):
         self.arch.close()
@@ -130,8 +130,7 @@ class TestAccessPoliciesPartnerID(TestCase):
                     "headers": {
                         "authorization": "Bearer authauthauth",
                         USER_AGENT: (
-                            f"{USER_AGENT_VALUE} "
-                            f"{USER_AGENT_PREFIX}{VERSION}"
+                            f"{USER_AGENT_VALUE} " f"{USER_AGENT_PREFIX}{VERSION}"
                         ),
                         PARTNER_ID: PARTNER_ID_VALUE,
                     },


### PR DESCRIPTION
User Agent is a property which can be prepended to by other packages such as datatrails-samples so that DataTrails-User-Agent is a list of agents.

datatrails-samples will have its own copy of the Archivist class that will add its own user-agent. Likewise for avid-samples-service.

Test_results:

[test_results.txt](https://github.com/user-attachments/files/16177486/test_results.txt)

Additionally the wheel was generated locally and imported into a branch for datatrails-samples. The datatrails-samples tests were run and segment output from pod logs inspected:

      Segment Handler: partnerID acmecorp    {"servicename": "assetsv2"}                                                   
      Segment Handler: userAgent samples/v0.17.1-2-g9d1a5d9 pysdk/v0.31.2-1-ge855a49-dirty

The 'dirty' moniker is because we are using branches.

[AB#9572](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9572)