### PR TITLE
Update merge-requires.yml

### DIFF
--- a/.github/workflows/merge-requires.yml
+++ b/.github/workflows/merge-requires.yml
@@ -12,7 +12,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/ci.yml
   release:
-    if: ${{ github.event_name == 'release' }}
     secrets: inherit
     uses: ./.github/workflows/package.yml
 
@@ -22,13 +21,14 @@ jobs:
     steps:
       - name: ok
         run: |
+          echo "event_name=${{ github.event_name}}" 
           echo "This code is mergeable"
 
   release-checks-ok:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' }}
     needs: [ci, release]
     steps:
       - name: ok
         run: |
+          echo "event_name=${{ github.event_name}}"
           echo "This code is releasable"

--- a/.github/workflows/merge-requires.yml
+++ b/.github/workflows/merge-requires.yml
@@ -1,19 +1,16 @@
 # This workflow configures the repository specific choices of which CI builds
-# must pass in order for a build to merge. This allows a sinlge global teraform
+# must pass in order for a build to merge. This allows a single global teraform
 # configured rule to require a "well known" check in each repository. Whilst
 # granting repository stakeholders the ability configure what workflows are
 # appropriate to satisfy that check.
 name: Merge Requires
-on:
-  push:
+
+on: [pull_request]
 
 jobs:
   ci:
     secrets: inherit
     uses: ./.github/workflows/ci.yml
-  release:
-    secrets: inherit
-    uses: ./.github/workflows/package.yml
 
   merge-checks-ok:
     runs-on: ubuntu-latest
@@ -21,14 +18,4 @@ jobs:
     steps:
       - name: ok
         run: |
-          echo "event_name=${{ github.event_name}}" 
           echo "This code is mergeable"
-
-  release-checks-ok:
-    runs-on: ubuntu-latest
-    needs: [ci, release]
-    steps:
-      - name: ok
-        run: |
-          echo "event_name=${{ github.event_name}}"
-          echo "This code is releasable"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,10 +4,11 @@
 name: Package and Publish
 
 on:
-  workflow_call:
+  release:
+    types: [created]
 
 jobs:
-  build:
+  deploy:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Fix github action
    
Remove the release requires logic - we dont want the release to be
triggered until we actually release otherwise the action erroneously
attempts to upload a wheel to pypi with a spurious 0.0.1 tag.
Additionally the release action publishes documentation to github pages
and that **must not** happen until we release.
    
This also simplifies logic in the merge-requires workflow - the test
for github.event_name == 'release' did not apparently work.

Tested extensively by adding debug statements and watching the release workflow fail badly
many time.

[AB#10062](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/10062)