### PR TITLE
Remove deprecated universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,13 +38,10 @@ packages =
 
 include_package_data = True
 platforms = any
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires = setuptools-git-versioning
 
 [options.entry_points]
 console_scripts =
     archivist_runner = archivist.cmds.runner.main:main
     archivist_template = archivist.cmds.template.main:main
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Universal wheels are deprecated:

        ********************************************************************************
        With Python 2.7 end-of-life, support for building universal wheels
        (i.e., wheels that support both Python 2 and Python 3)
        is being obviated.
        Please discontinue using this option, or if you still need it,
        file an issue with pypa/setuptools describing your use case.

        By 2025-Aug-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        ********************************************************************************

Additionally another classifier was incorrect

[AB#10062](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/10062)