### PR TITLE
Use trusted publisher and environment

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,4 +1,4 @@
-# This workflow will upload a Python Package using a release environmet and a trusted publisher.
+# This workflow will upload a Python Package using a release environment and a trusted publisher.
 # See PyPi management in the datatrails confluence service for an explanation.
 #
 # Create a trusted publisher for datatrails-python in pypi.org and delete any API tokens.
@@ -51,8 +51,8 @@ jobs:
       run: |
         rm -f archivist/about.py
         ./scripts/version.sh
-         python3 -m build --sdist
-         python3 -m build --wheel
+        python3 -m build --sdist
+        python3 -m build --wheel
       shell: bash
 
     - name: Publish to PyPi

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -60,7 +60,6 @@ jobs:
       with:
         verbose: true
         attestations: true
-        # skip-existing: true
 
     - name: Build docs
       run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,9 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow will upload a Python Package using a release environmet and a trusted publisher.
+# See PyPi management in the datatrails confluence service for an explanation.
+#
+# Create a trusted publisher for datatrails-python in pypi.org and delete any API tokens.
+# In github add an environment called release that is restricted to the main branch and
+# delete any PYPI secrets.
 
 name: Package and Publish
 
@@ -9,15 +13,19 @@ on:
 
 jobs:
   deploy:
+    environment: release
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
 
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
@@ -37,21 +45,29 @@ jobs:
         python3 -m pip install --upgrade pip
         python3 -m pip install -r requirements-dev.txt
         python3 -m pip install setuptools wheel
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      shell: bash
+
+    - name: Create wheel
       run: |
         rm -f archivist/about.py
         ./scripts/version.sh
-        python3 -m build --sdist
-        python3 -m build --wheel
-        twine check dist/*
-        twine upload dist/*
+         python3 -m build --sdist
+         python3 -m build --wheel
+      shell: bash
+
+    - name: Publish to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true
+        attestations: true
+        # skip-existing: true
+
     - name: Build docs
       run: |
         ./scripts/zipnotebooks.sh
         (cd docs && make clean && make html)
+      shell: bash
+
     - name: Publish docs
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
Setup PyPi for datatrails-python to use a trusted publisher. Delete any API tokens in PyPi for datatrails-python.

In github repo delete PYPI secrets and create an environmant called release that is restricted to the main branch.

Testing: can only be tested by merging and releasing: if this fails it will be refined and remerged and rereleased. Any wheels so uploaded will be marked as alpha and yanked to prevent access by third parties.